### PR TITLE
pkg/types: Add types necessary to service accounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/sneakynet/moneyprinter2
 
 go 1.23.6
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	gorm.io/gorm v1.25.12 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
+gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=

--- a/pkg/types/type.go
+++ b/pkg/types/type.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"gorm.io/gorm"
+)
+
+// A LEC or Local Exchange Company is the base unit of multi-tenancy
+// in moneyprinter.  The LEC is the operating company that services
+// customers.
+type LEC struct {
+	gorm.Model
+
+	ID uint
+	Name string
+	Byline string
+	Contact string
+	Website string
+}
+
+// Service defines one flat-rate billed services that a LEC provides
+// and an account can have.
+type Service struct {
+	gorm.Model
+
+	ID uint
+	Name string
+	Slug string
+}
+
+// An Account is the base unit of a customer bill.  This is the
+// element that unifies all of a customer's services, their bills, and
+// any credentials they might have that moneyprinter knows about.
+type Account struct {
+	gorm.Model
+
+	ID uint
+	Name string
+	Alias string
+	Contact string
+}
+
+// Premise refers to a location where service may be delivered.  The
+// intention is that these function somewhat like addresses, and allow
+// for quick identification of where things are.
+type Premise struct {
+	gorm.Model
+
+	ID uint
+	Address string
+}
+
+// A Wirecenter represents a constrained physical area that is served
+// from a single collection of equipment.
+type Wirecenter struct {
+	gorm.Model
+
+	ID uint
+	Name string
+}


### PR DESCRIPTION
This is the initial stab at types.  It does not yet include what the relations are between the types, but this should be enough to keep track of what LECs exist, the services they offer, and where these services are being delivered.