### PR TITLE
pkg/web: Move ports from NID to service

### DIFF
--- a/pkg/db/account.go
+++ b/pkg/db/account.go
@@ -23,6 +23,6 @@ func (db *DB) AccountList(filter *types.Account) ([]types.Account, error) {
 // AccountGet returns a single account identified by its specific ID
 func (db *DB) AccountGet(filter *types.Account) (types.Account, error) {
 	acct := types.Account{}
-	res := db.d.Where(filter).Preload("Premises.Wirecenter").Preload("Services.LECService").Preload("Services.LECService.LEC").Preload("Services.AssignedDN").Preload(clause.Associations).First(&acct)
+	res := db.d.Where(filter).Preload("Premises.Wirecenter").Preload("Services.LECService").Preload("Services.LECService.LEC").Preload("Services.AssignedDN").Preload("Services.EquipmentPort").Preload(clause.Associations).First(&acct)
 	return acct, res.Error
 }

--- a/pkg/db/nid.go
+++ b/pkg/db/nid.go
@@ -23,7 +23,7 @@ func (db *DB) NIDList(filter *types.NID) ([]types.NID, error) {
 // loaded.
 func (db *DB) NIDListFull(filter *types.NID) ([]types.NID, error) {
 	NIDs := []types.NID{}
-	res := db.d.Where(filter).Preload(clause.Associations).Preload("Premise.Wirecenter").Preload("Ports.Services.LECService").Preload("Ports.Services.AssignedDN").Preload("Ports.EquipmentPort.Equipment.Switch").Find(&NIDs)
+	res := db.d.Where(filter).Preload(clause.Associations).Preload("Premise.Wirecenter").Preload("Ports.Services.LECService").Preload("Ports.Services.AssignedDN").Find(&NIDs)
 	return NIDs, res.Error
 }
 

--- a/pkg/db/switch.go
+++ b/pkg/db/switch.go
@@ -59,7 +59,7 @@ func (db *DB) PortList(filter *types.Port) ([]types.Port, error) {
 // assigned somewhere else.
 func (db *DB) PortListAssigned() ([]types.Port, error) {
 	ports := []types.Port{}
-	res := db.d.Where("id in (?)", db.d.Table(types.NIDPort{}.TableName()).Select("equipment_port_id")).Find(&ports)
+	res := db.d.Where("id in (?)", db.d.Table(types.Service{}.TableName()).Select("equipment_port_id")).Find(&ports)
 	return ports, res.Error
 }
 
@@ -67,7 +67,7 @@ func (db *DB) PortListAssigned() ([]types.Port, error) {
 // anywhere.
 func (db *DB) PortListAvailable() ([]types.Port, error) {
 	ports := []types.Port{}
-	res := db.d.Where("id not in (?)", db.d.Table(types.NIDPort{}.TableName()).Select("equipment_port_id")).Find(&ports)
+	res := db.d.Where("id not in (?)", db.d.Table(types.Service{}.TableName()).Select("equipment_port_id")).Find(&ports)
 	return ports, res.Error
 }
 

--- a/pkg/types/nid.go
+++ b/pkg/types/nid.go
@@ -80,8 +80,6 @@ type NIDPort struct {
 
 	ID              uint
 	NIDID           uint
-	EquipmentPortID uint
-	EquipmentPort   Port
 
 	Services []Service `gorm:"many2many:service_appearances;"`
 }

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -10,13 +10,20 @@ import (
 type Service struct {
 	gorm.Model
 
-	ID           uint
-	LECServiceID uint
-	LECService   LECService
-	AccountID    uint
-	Account      Account
+	ID              uint
+	LECServiceID    uint
+	LECService      LECService
+	AccountID       uint
+	Account         Account
+	EquipmentPortID uint
+	EquipmentPort   Port
 
 	AssignedDN []DN `gorm:"many2many:dn_assignments;"`
+}
+
+// TableName satisfies the Tabler interface to make the name nicer.
+func (s Service) TableName() string {
+	return "services"
 }
 
 // DNList provides a cleaner text list of the assigned DNs

--- a/pkg/web/nid.go
+++ b/pkg/web/nid.go
@@ -82,28 +82,9 @@ func (s *Server) uiViewNIDPortProvisionForm(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	equipment, err := s.d.EquipmentList(&types.Equipment{WirecenterID: nidList[0].Premise.WirecenterID})
-	if err != nil {
-		s.doTemplate(w, r, "errors/internal.p2", pongo2.Context{"error": err.Error()})
-		return
-	}
-
-	assignedPorts, err := s.d.PortListAssigned()
-	if err != nil {
-		s.doTemplate(w, r, "errors/internal.p2", pongo2.Context{"error": err.Error()})
-		return
-	}
-
-	assigned := []uint{}
-	for _, p := range assignedPorts {
-		assigned = append(assigned, p.ID)
-	}
-
 	ctx := pongo2.Context{
 		"nid":           nidList[0],
 		"account":       account,
-		"equipment":     equipment,
-		"assignedPorts": assigned,
 		"next":          r.URL.Query().Get("next"),
 	}
 	s.doTemplate(w, r, "views/nid/form_port.p2", ctx)
@@ -118,7 +99,6 @@ func (s *Server) uiViewNIDPortProvision(w http.ResponseWriter, r *http.Request) 
 	nidPort := types.NIDPort{
 		ID:              s.strToUint(r.FormValue("nid_port_id")),
 		NIDID:           s.strToUint(chi.URLParam(r, "id")),
-		EquipmentPortID: s.strToUint(r.FormValue("equipment_port_id")),
 	}
 
 	if _, err := s.d.NIDPortSave(&nidPort); err != nil {

--- a/pkg/web/ui/p2/views/account/detail.p2
+++ b/pkg/web/ui/p2/views/account/detail.p2
@@ -28,16 +28,20 @@
       </div>
       <table>
         <tr>
+          <th>ID</th>
           <th>Service</th>
           <th>Provided By</th>
           <th>DNs</th>
+          <th>Equipment</th>
           <th>Actions</th>
         </tr>
         {% for service in account.Services %}
           <tr>
+            <td>{{ service.ID }}</td>
             <td>{{ service.LECService.Name }}</td>
             <td>{{ service.LECService.LEC.Name }}</td>
             <td>{{ service.DNList }}</td>
+            <td>{{ service.EquipmentPort.Personality }} - {{ service.EquipmentPort.Number }}</td>
             <td>
               <div class="flex-container flex-row flex-center">
                 <a class="flex-item button" href="/ui/admin/accounts/{{ account.ID }}/order-service/{{ service.ID }}">Edit</a>
@@ -124,18 +128,12 @@
                     <th>Port</th>
                     <th>Service</th>
                     <th>DN</th>
-                    <th>Equipment</th>
                   </tr>
                   {% for port in nid.Ports %}
                     <tr>
                       <td>{{ forloop.Counter }}</td>
                       <td>{{ port.ServiceList() }}</td>
                       <td>{{ port.AllDNs() }}</td>
-                      <td>
-                        {% if port.AllDNs() != "" %}
-                          <a href="/ui/admin/switches/{{ port.EquipmentPort.Equipment.Switch.ID }}">{{ port.EquipmentPort.Equipment.Switch.CLLI }}</a> - {{ port.EquipmentPort.Number }} ({{ port.EquipmentPort.Personality }})
-                        {% endif %}
-                      </td>
                     </tr>
                   {% endfor %}
                 </table>

--- a/pkg/web/ui/p2/views/account/order_service.p2
+++ b/pkg/web/ui/p2/views/account/order_service.p2
@@ -39,6 +39,20 @@
               </select>
             </td>
           </tr>
+          <tr>
+            <td><label for="equipment_port_id">Equipment Port:</label></td>
+            <td>
+              <select name="equipment_port_id">
+                {% for eq in Equipment %}
+                  <optgroup label="{{ eq.Type }}">
+                    {% for port in eq.Ports %}
+                      <option value="{{ port.ID }}" {% if port.ID == Order.EquipmentPortID %}selected{% endif %}>{% if port.ID in Assigned %}(A) {% endif %}{{ port.Number }} ({{ port.Personality }})</option>
+                    {% endfor %}
+                  </optgroup>
+                {% endfor %}
+              </select>
+            </td>
+          </tr>
           <tr class="center">
             <td colspan="2"><input type="submit" value="Submit" /></td>
           </tr>

--- a/pkg/web/ui/p2/views/nid/form_port.p2
+++ b/pkg/web/ui/p2/views/nid/form_port.p2
@@ -45,20 +45,6 @@
             </td>
           </tr>
           <tr>
-            <td><label for="equipment_port_id">Equipment Port:</label></td>
-            <td>
-              <select name="equipment_port_id">
-                {% for eq in equipment %}
-                  <optgroup label="{{ eq.Type }}">
-                    {% for port in eq.Ports %}
-                      <option value="{{ port.ID }}">{% if port.ID in assignedPorts %}(A) {% endif %}{{ port.Number }} ({{ port.Personality }})</option>
-                    {% endfor %}
-                  </optgroup>
-                {% endfor %}
-              </select>
-            </td>
-          </tr>
-          <tr>
             <td colspan="2"><input type="submit" value="Save" />
           </tr>
         </table>

--- a/pkg/web/ui/p2/views/work/premise.p2
+++ b/pkg/web/ui/p2/views/work/premise.p2
@@ -27,17 +27,11 @@
                   <tr>
                     <th>Port</th>
                     <th>DN</th>
-                    <th>Equipment</th>
                   </tr>
                   {% for port in nid.Ports %}
                     <tr>
                       <td>{{ forloop.Counter }}</td>
                       <td>{{ port.AllDNs() }}</td>
-                      <td>
-                        {% if port.AllDNs() != "" %}
-                          <a href="/ui/admin/switches/{{ port.EquipmentPort.Equipment.Switch.ID }}">{{ port.EquipmentPort.Equipment.Switch.CLLI }}</a> - {{ port.EquipmentPort.Number }} ({{ port.EquipmentPort.Personality }})
-                        {% endif %}
-                      </td>
                     </tr>
                   {% endfor %}
                 </table>


### PR DESCRIPTION
Moves equipment ports to be part of service orders.  This removes the ability to filter by premise, as that isn't part of the account metadata during service ordering, but does make the overall data model more sane.

Resolves #2 